### PR TITLE
Support multiple .net versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ./src/DotNetDelice
 
       - name: Publish release packages
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: ${{ env.OUTPUT_PATH }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI build
 
 env:
   OUTPUT_PATH: ${{ github.workspace }}/.nupkg
-  DOTNET_VERSION: "6.0.x"
+  DOTNET_VERSION: |
+    8.0.x
+    6.0.x
   GITHUB_SOURCE: "https://nuget.pkg.github.com/aaronpowell/index.json"
   CONFIGURATION: "Debug"
 
@@ -21,8 +23,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Dotnet ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -54,8 +56,8 @@ jobs:
           name: packages
           path: ${{ env.OUTPUT_PATH }}
 
-      - name: Setup .NET Core ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet fake run ./build.fsx --target Release
 
       - name: Publish release packages
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: ${{ env.OUTPUT_PATH }}
@@ -53,7 +53,7 @@ jobs:
           body_path: ${{ env.OUTPUT_PATH }}/changelog.md
       - run: echo ${{ steps.create_release.outputs.id }} >> release.txt
       - name: Upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
             name: release_id
             path: release.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release build
 
 env:
   OUTPUT_PATH: ${{ github.workspace }}/.nupkg
-  DOTNET_VERSION: "6.0.x"
+  DOTNET_VERSION: |
+    8.0.x
+    6.0.x
   GITHUB_SOURCE: "https://nuget.pkg.github.com/aaronpowell/index.json"
   NUGET_SOURCE: "https://api.nuget.org/v3/index.json"
 
@@ -19,8 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup Dotnet ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -133,8 +135,8 @@ jobs:
           name: packages
           path: ${{ env.OUTPUT_PATH }}
 
-      - name: Setup .NET Core ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -154,8 +156,8 @@ jobs:
           name: packages
           path: ${{ env.OUTPUT_PATH }}
 
-      - name: Setup .NET Core ${{ env.DOTNET_VERSION }}
-        uses: actions/setup-dotnet@v1
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 

--- a/src/DotNetDelice.Licensing/DotNetDelice.Licensing.fsproj
+++ b/src/DotNetDelice.Licensing/DotNetDelice.Licensing.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <PackageOutputPath>../../.nupkg</PackageOutputPath>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/aaronpowell/dotnet-delice.git</RepositoryUrl>

--- a/src/DotNetDelice.Licensing/DotNetDelice.Licensing.fsproj
+++ b/src/DotNetDelice.Licensing/DotNetDelice.Licensing.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageOutputPath>../../.nupkg</PackageOutputPath>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/aaronpowell/dotnet-delice.git</RepositoryUrl>

--- a/src/DotNetDelice/DotNetDelice.fsproj
+++ b/src/DotNetDelice/DotNetDelice.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-delice</ToolCommandName>

--- a/src/DotNetDelice/DotNetDelice.fsproj
+++ b/src/DotNetDelice/DotNetDelice.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-delice</ToolCommandName>


### PR DESCRIPTION
Hello ! :)

.net 6 is going to be out of maintenance soon.
.net 9 is going to be RTM soon.

So a simple PR to support multiple versions: net6, net7, net8.

This should not break existing users, and should allow new ones to use net8 directly without downloading legacy stuff.

After that, if you want (that would be great), you just need to bump the package version and submit the new nupkg that will contain all versions.

![image](https://github.com/user-attachments/assets/78e450c5-69ee-4b4f-a883-8d0dde011cc8)

Thank you !