### PR TITLE
Add support for slnx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dotnet tool install -g dotnet-delice
 You can then use it like so:
 
 ```
-dotnet delice [folder, sln, csproj, fsproj]
+dotnet delice [folder, sln, slnx, csproj, fsproj]
 ```
 
 ## Commands
@@ -67,6 +67,10 @@ License Expression: MIT
 
 - Ability to filter for only a particular license
 - Anything you'd like? Open an [issue](https://github.com/aaronpowell/dotnet-delice/issues) 😁
+
+# Slnx support
+
+XML-based solution file format (slnx) are supported, but you need at least a `.NET 9.0.201 SDK` which provides support for interacting with these files.
 
 # Undetermined Licenses
 

--- a/src/DotNetDelice/App.fs
+++ b/src/DotNetDelice/App.fs
@@ -16,6 +16,7 @@ let (|Proj|_|) arg =
         String.Compare(str, arg, StringComparison.OrdinalIgnoreCase) = 0
 
     if c ".sln" then Some()
+    elif c ".slnx" then Some()
     elif c ".csproj" then Some()
     elif c ".fsproj" then Some()
     else None
@@ -28,7 +29,7 @@ let findProject path =
         | Proj -> Path.GetFullPath path
         | _ -> failwith "Path is not a valid project or solution path"
     | (_, true) ->
-        match Directory.GetFiles(path, "*.sln") with
+        match Directory.GetFiles(path, "*.sln") |> Array.append <| Directory.GetFiles(path, "*.slnx") with
         | [| sln |] -> Path.GetFullPath sln
         | [||] ->
             match
@@ -87,7 +88,7 @@ let getLicensesForTool checkGitHub token checkLicenseContent (projectSpec: Packa
 type Cli() =
 
     [<Argument(0,
-               Description = "The path to a .sln, .csproj or .fsproj file, or to a directory containing a .NET Core solution/project. If none is specified, the current directory will be used.")>]
+               Description = "The path to a .sln, .slnx, .csproj or .fsproj file, or to a directory containing a .NET Core solution/project. If none is specified, the current directory will be used.")>]
     member val Path = "" with get, set
 
     [<Option(Description = "Output result as JSON")>]


### PR DESCRIPTION
### Add support for XML-based solution files (`slnx`).

Given `dotnet-delice` is using `msbuild /t:GenerateRestoreGraphFile ...` to generate a graph file, it is quite easy to add support for `slnx`.

We just need:
- to expand solution search to `slnx` files in the application.
- to use a compatible `.NET 9.0.201 SDK` on the user side so that `msbuild` and other tools provide support for interacting with these files.

### References:
https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/